### PR TITLE
update home dir of root user

### DIFF
--- a/02enabletelnet.sh
+++ b/02enabletelnet.sh
@@ -17,7 +17,7 @@ fi
 if grep -q 'root:/sbin/nologin' /etc/passwd
 then
     echo enable root shell
-    sed -i "s|:/root:/sbin/nologin|:/root:/bin/sh|" /etc/passwd
+    sed -i "s|:/root:/sbin/nologin|:/:/bin/sh|" /etc/passwd
 fi
 #if grep -q '/bin/sh-new' /etc/*passwd
 #then


### PR DESCRIPTION
- normally /root is the home dir of the user root, but this directory does not seem to exist on any of the firmware or hardware revisions
- updating this to / (which is the fallback anyway) will prevent error messages such as "login: can't chdir to home directory '/root'"
